### PR TITLE
add missing Yogh tests

### DIFF
--- a/src/test/java/ca/nines/ise/node/chr/UnicodeCharNodeTest.java
+++ b/src/test/java/ca/nines/ise/node/chr/UnicodeCharNodeTest.java
@@ -68,6 +68,8 @@ public class UnicodeCharNodeTest extends TestBase {
     testExpansion("{C}", "\u00C7");
     testExpansion("{th}", "\u00FE");
     testExpansion("{TH}", "\u00DE");
+    testExpansion("{Y}", "\u021C");
+    testExpansion("{y}", "\u021D");
     testExpansion("{pd}", "\uFFFD", new String[]{"char.unicode.unknown"});
   }
 


### PR DESCRIPTION
to go with the added `{y}` and `{Y}` escapes added in emmental@f4a4a0d8e0753fd79843e24183e046935adf46b0