### PR TITLE
remove SPLITLINE

### DIFF
--- a/src/main/java/ca/nines/ise/writer/XMLWriter.java
+++ b/src/main/java/ca/nines/ise/writer/XMLWriter.java
@@ -107,6 +107,7 @@ public class XMLWriter extends Writer{
 			TYPEFACES = array_to_lower(schema.get_typeface_tags());
 			DONT_PARSE_TEXT = array_to_lower(schema.get_unparsed_text_tags());
 			LINE_PARENTS = array_to_lower(schema.get_line_parent_tags());
+			LINE_PARENTS.add("splitline");
 		  renewable = schema.get_Inline_tags();
 			this.xml = xml;
 			renewing = new LinkedList<LinkedList<Element>>();

--- a/src/main/resources/schemas/default.xml
+++ b/src/main/resources/schemas/default.xml
@@ -416,9 +416,6 @@
     <tag name="BRACEGROUP" where="all" xml_line_parent="yes">
 		<desc><![CDATA[Bracegroup]]></desc>
     </tag>
-    <tag name="SPLITLINE" where="all" xml_line_parent="yes">
-		<desc><![CDATA[Line split into multiple lines]]></desc>
-    </tag>
     <tag name="MARG" where="all" xml_line_parent="yes">
       <desc><![CDATA[Marginalia]]></desc>
       <attribute name="loc" type="select">


### PR DESCRIPTION
This was never actually a thing as far as I know (we use `L[@part]` for split lines).